### PR TITLE
FIX: Warning calling "createRoot" twice

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,9 @@ const App = () => {
   )
 }
 
+const root = ReactDOM.createRoot(document.getElementById('root'))
 const renderApp = () => {
-  ReactDOM.createRoot(document.getElementById('root')).render(<App />)
+  root.render(<App />)
 }
 
 renderApp()


### PR DESCRIPTION
This is a FIX mitigating the warning that createRoot is being called twice or more when the button is clicked. I have changed the way the App component is re-rendered by Redux