### PR TITLE
Remove default value from counterReducer

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -4,7 +4,7 @@ const initialState = {
   bad: 0
 }
 
-const counterReducer = (state = initialState, action) => {
+const counterReducer = (state, action) => {
   console.log(action)
   switch (action.type) {
     case 'GOOD':


### PR DESCRIPTION
Remove initialState default value in the counterReducer so that this test fails:

```
  test("should return a proper initial state when called with undefined state", () => {
    const state = {};
    const action = {
      type: "DO_NOTHING",
    };

    const newState = counterReducer(undefined, action);
    expect(newState).toEqual(initialState);
  });
```

From reading exercise 6.1 it seems like the intent is to have the student fix the reducer so the test passes. As it is currently written the test passes without any changes.